### PR TITLE
Add microbadger badge and adds links to included tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # TeX Live-2017 with Pygments and LaTeXML
 
 [![TexLive:2017](https://img.shields.io/badge/TeX%20Live-2017-blue.svg)](https://www.tug.org/texlive/acquire.html)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
+[![](https://images.microbadger.com/badges/image/sumdoc/texlive-2017.svg)](https://microbadger.com/images/sumdoc/texlive-2017 "Get your own image badge on microbadger.com")
 
-Contains full TeXLive-2017 with additional python-pygments library for source code highlighting via minted package.
-Also contains LateXML for converting TeX documents into html/xml/mathml.
+Contains full TeXLive-2017 with additional [python-pygments library](http://pygments.org/) for source code highlighting via [minted package](https://www.ctan.org/pkg/minted).
+Also contains [LateXML](https://dlmf.nist.gov/LaTeXML/) for converting TeX documents into html/xml/mathml.
 
 
 ## How to get the image?


### PR DESCRIPTION
I like hyperlinks 😇 and thus, I added some of them to the tools included in this image.

Furthermore, [microbadger](https://microbadger.com/) offers nice badges for docker images.

Example: 

![grafik](https://user-images.githubusercontent.com/1366654/36469461-92b2ce68-16e7-11e8-97d3-af59e6852d8b.png)

I thought, such kind of an image would also be good here.